### PR TITLE
Add new Chatbot data structure

### DIFF
--- a/crates/chatbot/src/lib.rs
+++ b/crates/chatbot/src/lib.rs
@@ -20,27 +20,30 @@ pub async fn gen_random_number() -> usize {
 
 /// A chatbot that responds to inputs.
 pub struct Chatbot {
-    emoji: String,
+    emojis: Vec<String>,
+    emoji_counter: usize,
 }
 
 impl Chatbot {
     /// Creates a new chatbot that uses the provided emoji in its responses.
-    pub fn new(emoji: String) -> Self {
-        Chatbot { emoji }
+    pub fn new(emojis: Vec<String>) -> Self {
+        Chatbot {
+            emojis,
+            emoji_counter: 0,
+        }
     }
 
     /// Generates a list of possible responses given the current chat.
     ///
     /// Warning: may take a few seconds!
-    pub async fn query_chat(&self, messages: &[String]) -> Vec<String> {
+    pub async fn query_chat(&mut self, messages: &[String]) -> Vec<String> {
         std::thread::sleep(Duration::from_secs(2));
         let most_recent = messages.last().unwrap();
+        let emoji = &self.emojis[self.emoji_counter];
+        self.emoji_counter = (self.emoji_counter + 1) % self.emojis.len();
         vec![
-            format!(
-                "\"{most_recent}\"? And how does that make you feel? {}",
-                self.emoji
-            ),
-            format!("\"{most_recent}\"! Interesting! Go on... {}", self.emoji),
+            format!("\"{most_recent}\"? And how does that make you feel? {emoji}",),
+            format!("\"{most_recent}\"! Interesting! Go on... {emoji}"),
         ]
     }
 }

--- a/crates/chatbot/src/lib.rs
+++ b/crates/chatbot/src/lib.rs
@@ -18,14 +18,29 @@ pub async fn gen_random_number() -> usize {
     RNG.with(|rng| rng.borrow_mut().gen())
 }
 
-/// Generates a list of possible responses given the current chat.
-///
-/// Warning: may take a few seconds!
-pub async fn query_chat(messages: &[String]) -> Vec<String> {
-    std::thread::sleep(Duration::from_secs(2));
-    let most_recent = messages.last().unwrap();
-    vec![
-        format!("\"{most_recent}\"? And how does that make you feel?"),
-        format!("\"{most_recent}\"! Interesting! Go on..."),
-    ]
+/// A chatbot that responds to inputs.
+pub struct Chatbot {
+    emoji: String,
+}
+
+impl Chatbot {
+    /// Creates a new chatbot that uses the provided emoji in its responses.
+    pub fn new(emoji: String) -> Self {
+        Chatbot { emoji }
+    }
+
+    /// Generates a list of possible responses given the current chat.
+    ///
+    /// Warning: may take a few seconds!
+    pub async fn query_chat(&self, messages: &[String]) -> Vec<String> {
+        std::thread::sleep(Duration::from_secs(2));
+        let most_recent = messages.last().unwrap();
+        vec![
+            format!(
+                "\"{most_recent}\"? And how does that make you feel? {}",
+                self.emoji
+            ),
+            format!("\"{most_recent}\"! Interesting! Go on... {}", self.emoji),
+        ]
+    }
 }


### PR DESCRIPTION
Refactors `chatbot::query_chat` into a method on the `Chatbot` data structure. This causes the build to break for the `server` crate. The main changes are:
* `Chatbot::new` takes as input a vector of emojis, which the chatbot will include to improve the attitude of users.
* `Chatbot::query_chat` is stateful because it rotates through emojis to keep the chat fresh.